### PR TITLE
Adds route middlewares

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,8 @@ let package = Package(
     .testTarget(
       name: "GinnyTests",
       dependencies: [
-        "Ginny"
+        "Ginny",
+        .product(name: "XCTVapor", package: "vapor"),
       ]),
 
     .executableTarget(

--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ Ginny supports most of Vapor's routing features at the moment. Support for missi
 
 - [x] [Catchall parameters](https://docs.vapor.codes/basics/routing/#catchall): Vapor's catchall parameters are supported with a `...` syntax. For example, a file named `api/user/[...slug].swift` ends up getting registered with Vapor as `api/user/***` and allows you to later retrieve the catchall. The `slug` part does not matter, you can name that whatever you'd like (and you'll have to if you want to have multiple files in the same module that support catchall parameters because you can't have two files in the same Swift module with the same name)
 
+- [x] [Route middleware](https://docs.vapor.codes/basics/routing/#route-groups): Vapor's route middlewares are supported by providing a `middlewares` array within your `RequestHandler` that will be additionally grouped with the app's current middlewares
+
 #### Not yet supported
 
 - [ ] [Anything parameters](https://docs.vapor.codes/basics/routing/#anything)
-- [ ] [Route groups and middleware](https://docs.vapor.codes/basics/routing/#route-groups)
+- [ ] [Route groups](https://docs.vapor.codes/basics/routing/#route-groups)
 - [ ] [Metadata](https://docs.vapor.codes/basics/routing/#metadata)
 
 ## Inspiration

--- a/Sources/Example/main.swift
+++ b/Sources/Example/main.swift
@@ -11,5 +11,6 @@ import Vapor
 let app = try Application(.detect())
 defer { app.shutdown() }
 
+app.middleware.use(DoSomethingMiddleware())
 app.registerRoutes()
 try app.run()

--- a/Sources/Example/middlewares.swift
+++ b/Sources/Example/middlewares.swift
@@ -1,0 +1,25 @@
+//
+//  Middlewares.swift
+//  
+//
+//  Created by Mauricio Cardozo on 27/07/23.
+//
+
+import Foundation
+import Vapor
+
+struct DoSomethingMiddleware: AsyncMiddleware {
+  func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+    let response = try await next.respond(to: request)
+    response.headers.add(name: "Something-Header", value: "Something")
+    return response
+  }
+}
+
+struct DoSomethingElseMiddleware: AsyncMiddleware {
+  func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+    let response = try await next.respond(to: request)
+    response.headers.add(name: "Something-Else-Header", value: "Something Else")
+    return response
+  }
+}

--- a/Sources/Example/pages/api/hello/world/world.index.swift
+++ b/Sources/Example/pages/api/hello/world/world.index.swift
@@ -20,6 +20,10 @@ struct GetWorld: RequestHandler {
   func handle(req: Request) throws -> String {
     "Hello, world!"
   }
+
+  var middlewares: [Middleware] = [
+    DoSomethingElseMiddleware()
+  ]
 }
 
 // MARK - PostWorld

--- a/Sources/Ginny/Application+RequestHandler.swift
+++ b/Sources/Ginny/Application+RequestHandler.swift
@@ -19,8 +19,11 @@ extension AsyncRequestHandler {
      - path: The path to register the handler for.
    */
   public func register(in app: Application, for path: String) {
-    app.on(method, path.pathComponents) { [handle] req async throws in
-      try await handle(req)
+    app
+      .grouped(middlewares)
+      .on(method, path.pathComponents)
+    { [handle] req async throws in
+      return try await handle(req)
     }
   }
 }
@@ -36,7 +39,10 @@ extension RequestHandler {
      - path: The path to register the handler for.
    */
   public func register(in app: Application, for path: String) {
-    app.on(method, path.pathComponents) { [handle] req throws in
+    app
+      .grouped(middlewares)
+      .on(method, path.pathComponents)
+    { [handle] req throws in
       try handle(req)
     }
   }

--- a/Sources/Ginny/AsyncRequestHandler.swift
+++ b/Sources/Ginny/AsyncRequestHandler.swift
@@ -27,4 +27,11 @@ public protocol AsyncRequestHandler {
   ///
   /// - Returns: An `AsyncResponseEncodable` response.
   func handle(req: Request) async throws -> Response
+
+  /// The additional middleware group that should be applied to this request
+  var middlewares: [Middleware] { get }
+}
+
+public extension AsyncRequestHandler {
+  var middlewares: [Middleware] { [] }
 }

--- a/Sources/Ginny/RequestHandler.swift
+++ b/Sources/Ginny/RequestHandler.swift
@@ -27,4 +27,11 @@ public protocol RequestHandler {
   ///
   /// - Returns: The response to the request.
   func handle(req: Request) throws -> Response
+
+  /// The additional middleware group that should be applied to this request
+  var middlewares: [Middleware] { get }
+}
+
+public extension RequestHandler {
+  var middlewares: [Middleware] { [] }
 }

--- a/Tests/GinnyTests/RequestHandlerTests.swift
+++ b/Tests/GinnyTests/RequestHandlerTests.swift
@@ -7,6 +7,7 @@
 
 import Vapor
 import XCTest
+import XCTVapor
 
 @testable import Ginny
 
@@ -33,6 +34,27 @@ final class RequestHandlerTests: XCTestCase {
     XCTAssertEqual(app.routes.all.count, 1)
     XCTAssertTrue(app.routes.all.contains { $0.path.string == "api/hello" })
   }
+
+  func testMiddleware() async throws {
+    let app = Application(.testing)
+    defer { app.shutdown() }
+
+    app.middleware.use(DoSomethingMiddleware())
+    AsyncIndex().register(in: app, for: "api/async")
+    Index().register(in: app, for: "api/sync")
+
+    try app.test(.GET, "api/async") { response in
+      XCTAssertEqual(String(buffer: response.body), "Hello, world")
+      XCTAssertTrue(response.headers.contains(name: "Something-Header"))
+      XCTAssertTrue(response.headers.contains(name: "Something-Else-Header"))
+    }
+
+    try app.test(.GET, "api/sync") { response in
+      XCTAssertEqual(String(buffer: response.body), "Hello, world")
+      XCTAssertTrue(response.headers.contains(name: "Something-Header"))
+      XCTAssertFalse(response.headers.contains(name: "Something-Else-Header"))
+    }
+  }
 }
 
 // MARK: - Index
@@ -58,5 +80,25 @@ struct AsyncIndex: AsyncRequestHandler {
 
   func handle(req: Request) async throws -> some AsyncResponseEncodable {
     "Hello, world"
+  }
+
+  var middlewares: [Middleware] = [DoSomethingElseMiddleware()]
+}
+
+// MARK: - Middlewares
+
+struct DoSomethingMiddleware: AsyncMiddleware {
+  func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+    let response = try await next.respond(to: request)
+    response.headers.add(name: "Something-Header", value: "Something")
+    return response
+  }
+}
+
+struct DoSomethingElseMiddleware: AsyncMiddleware {
+  func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+    let response = try await next.respond(to: request)
+    response.headers.add(name: "Something-Else-Header", value: "Something Else")
+    return response
   }
 }


### PR DESCRIPTION
This PR provides a way for `RequestHandler`s to provide their own middlewares for a given endpoint, as such: 

```
struct GetWorld: RequestHandler {

  var method: HTTPMethod {
    .GET
  }

  func handle(req: Request) throws -> String {
    "Hello, world!"
  }

  var middlewares: [Middleware] = [
    DoSomethingElseMiddleware()
  ]
}
```

These middlewares are optional and will be grouped with all the middlewares that were enabled with `app.middleware.use()`